### PR TITLE
Fix minor minipro syntax issues

### DIFF
--- a/Apple2Arduino/Makefile
+++ b/Apple2Arduino/Makefile
@@ -1,7 +1,7 @@
 all: Apple2Arduino.ino.hex fuses.cfg
 	@echo To burn the firmware under Linux, execute:
 	@echo -e "\tminipro -p 'ATMEGA328P@DIP28' -c code -w Apple2Arduino.ino.hex -f ihex -e"
-	@echo -e "\tminipro -p 'ATMEGA328P@DIP28' -c config -w fuses.cfg -e"
+	@echo -e "\tminipro -p 'ATMEGA328P@DIP28' -c config -w fuses.cfg"
 
 Apple2Arduino.ino.hex:
 	arduino-cli compile -b arduino:avr:uno --output-dir . Apple2Arduino.ino

--- a/Apple2Arduino/fuses.cfg
+++ b/Apple2Arduino/fuses.cfg
@@ -1,4 +1,11 @@
+# new syntax
 lfuse = 0xff
 hfuse = 0xde
 efuse = 0xfd
 lock = 0xff
+
+# old syntax
+fuses_lo = 0xff
+fuses_hi = 0xde
+fuses_ext = 0xfd
+lock_byte = 0xff


### PR DESCRIPTION
softwarejanitor at applefritter pointed out that -e shouldn't be there, and that older versions of the minipro utility use different syntax for fuses.cfg.

These two commits fix that.